### PR TITLE
Fix double borders on tabs

### DIFF
--- a/libraryroot.custom.css
+++ b/libraryroot.custom.css
@@ -890,6 +890,8 @@ html._2GpKTB_eizdXpH2xVGbMKi body {
     margin-top: 0px;
     border: unset !important;
     border-left: 1px solid var(--minimal_dark_be_grey) !important;
+    border-top: 1px solid var(--minimal_dark_be_grey) !important;
+    border-bottom: 1px solid var(--minimal_dark_be_grey) !important;
     border-top: none;
     border-bottom: none !important;
     transform: translate(1px, 0px) !important;

--- a/libraryroot.custom.css
+++ b/libraryroot.custom.css
@@ -888,7 +888,8 @@ html._2GpKTB_eizdXpH2xVGbMKi body {
     font-size: 13px !important;
     height: 36px !important;
     margin-top: 0px;
-    border: 1px solid var(--minimal_dark_be_grey) !important;
+    border: unset !important;
+    border-left: 1px solid var(--minimal_dark_be_grey) !important;
     border-top: none;
     border-bottom: none !important;
     transform: translate(1px, 0px) !important;
@@ -900,6 +901,7 @@ html._2GpKTB_eizdXpH2xVGbMKi body {
 
 ._7AlhCx3XGzBeIrQaCneUD:last-child {
     padding-right: 10px !important;
+    border-right: 1px solid var(--minimal_dark_be_grey) !important;
 }
 
 ._7AlhCx3XGzBeIrQaCneUD:hover {


### PR DESCRIPTION
Fixes the double borders on the tabs of the titlebar.
## Before
![Before](https://github.com/user-attachments/assets/c24bdff0-4b0e-4d78-a76c-0a362ea7d19c)
## After
![After](https://github.com/user-attachments/assets/97025e64-e905-4ed7-adbc-0db01eee37a9)

# Extra info
There may be a more efficient fix but this is what I found that worked.