### PR TITLE
Hide empty showcase slot.

### DIFF
--- a/elements/options/webkit_no_empty_showcase.css
+++ b/elements/options/webkit_no_empty_showcase.css
@@ -1,0 +1,3 @@
+.profile_customization.customization_edit.none_selected {
+    display: none !important;
+}

--- a/skin.json
+++ b/skin.json
@@ -1183,7 +1183,7 @@
 		},
 		
 		"Compact Webkit :": {
-		"tab": "Webkit options (6)",
+		"tab": "Webkit options (7)",
 		"description": "> Hide the left sidebar on the webkit homepage. \n\n - Hide : Hide left sidebar on homepage. \n - Show : Show left sidebar webkit.",
 		"default": "Hide",
 		"values": {
@@ -1195,9 +1195,23 @@
 				}
 			}
 		},
+
+		"Hide empty showcase :": {
+		"tab": "Webkit options (7)",
+		"description": "> Hide empty showcase slot on your Steam profile. \n\n - Hide : Hide '+ Add a showcase' on your Steam profile. \n - Show : Show '+ Add a showcase' on your Steam profile.",
+		"default": "show",
+		"values": {
+			"Show": {},
+			"Hide": {
+			"TargetCss": {
+			"affects": [".*"], "src": "elements/options/webkit_no_empty_showcase.css"
+					}
+				}
+			}
+		},
 		
 		"Hide footers :": {
-		"tab": "Webkit options (6)",
+		"tab": "Webkit options (7)",
 		"description": "> Hide Steam information on webkit footers. \n\n - Hide : Hide legal informations at the bottom page of browser. \n - Show : Show legal informations at the bottom page of browser.",
 		"default": "Hide",
 		"values": {
@@ -1211,7 +1225,7 @@
 		},
 		
 		"Events header :": {
-		"tab": "Webkit options (6)",
+		"tab": "Webkit options (7)",
 		"description": "> Show or remove the events wallpaper on the webkit homepage. \n\n - Minimal Dark : Event wallpaper are displayed. \n - Hide : Events header are hidden.",
 		"default": "Minimal Dark default",
 		"values": {
@@ -1225,7 +1239,7 @@
 		},
 		
 		"Profiles :": {
-		"tab": "Webkit options (6)",
+		"tab": "Webkit options (7)",
 		"description": "> Enabling this option makes the profile page blocks full and removes the blur effect. \n\n - Minimal Dark : Blurred blocs. \n - No blur blocs : Solid black color blocs.",
 		"default": "Minimal Dark",
 		"values": {
@@ -1239,7 +1253,7 @@
 		},
 		
 		"Profiles headers :": {
-		"tab": "Webkit options (6)",
+		"tab": "Webkit options (7)",
 		"description": "> If you are using profile skin (or not), enable this option to view the color of the predefined block headers in the profile you applied (also displays on the profiles you view).",
 		"default": "no",
 		"values": {
@@ -1253,7 +1267,7 @@
 		},
 		
 		"URL bar :": {
-		"tab": "Webkit options (6)",
+		"tab": "Webkit options (7)",
 		"description": "> This option allows you to permanently hide the URL bar or display it only on hover. \n\n - Visible : Steam default. \n - Hide : Hide the url bar. \n - Only show on hover : Show the url bar only on mouseover.",
 		"default": "Visible",
 		"values": {


### PR DESCRIPTION
Hide stupid "Add showcase" from your profile.

Before:
<img width="1224" height="770" alt="20250915_063229" src="https://github.com/user-attachments/assets/d65122a2-09b7-4e3b-831d-4b1e72c89310" />

After:
<img width="1224" height="770" alt="20250915_063258" src="https://github.com/user-attachments/assets/9af4b943-919f-4cd5-ae51-b4e7880a5453" />
