### PR TITLE
Fix: Store Navigation Placeholder Removed

### DIFF
--- a/webkit.css
+++ b/webkit.css
@@ -16076,6 +16076,10 @@ body.v7menu .v7menu_spacer {
 	transition: .25s ease-out !important;
 }
 
+.PlaceholderInner {
+     display: none;
+}
+
 .-bDCBiZsIWB-_6IzGxbhz._2SVHFh60yRjQbYRg6t2mcK ._15eaL848WovXjJ0POHaD9D {
     background: linear-gradient(180deg, rgb(18 18 18 / 0%) -5%, var(--minimal_dark_blacker_alt) 100%) !important;
     border-radius: var(--minimal_dark_corner) !important;


### PR DESCRIPTION
removes this blue bar from loading before the custom navigation
<img width="1854" height="133" alt="image" src="https://github.com/user-attachments/assets/3e7155af-873b-4738-b83b-56b2224393b1" />
