### PR TITLE
Two fixes + Friends List Context Menu Revamp

### DIFF
--- a/elements/options/friends_options/header_glow.css
+++ b/elements/options/friends_options/header_glow.css
@@ -1,3 +1,3 @@
-.friendsui-container .statusHeaderGlow {
+.focused:not(.singlewindow) .title-area-highlight, .singleWindowFocusBar, .friendsui-container .statusHeaderGlow {
     display: none !important;
 }

--- a/elements/options/topbar_options/4k_alignment_fix.css
+++ b/elements/options/topbar_options/4k_alignment_fix.css
@@ -6,6 +6,10 @@
     margin-top: 1px !important;
 }
 
-._2Szzh5sKyGgnLUR870zbDE{
+._2Szzh5sKyGgnLUR870zbDE {
 	margin-top: 1px !important;
+}
+
+._3h-QRJGxnVOIExtHD1R0f2 {
+    margin-left: 0.5px !important;
 }

--- a/elements/options/various_options/extendium_patch.css
+++ b/elements/options/various_options/extendium_patch.css
@@ -1,0 +1,23 @@
+.extension-button,
+.extension-button:hover,
+.extension-button:active,
+.extension-button:focus,
+.extension-button:focus-visible {
+    background: transparent !important;
+    box-shadow: none !important;
+    outline: none !important;
+    transition: .25s ease-out !important;
+}
+
+.extensions-bar-container *:has(> .extension-button):hover,
+.extensions-bar-container *:has(> .extension-button:focus-visible),
+.extensions-bar-container *:has(> .extension-button:focus-within) {
+  border-color: rgba(0,0,0,0) !important;
+  border: 1px solid rgba(0,0,0,0) !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+.extension-button:hover svg {
+    color: var(--minimal_dark_color) !important
+}

--- a/friends.custom.css
+++ b/friends.custom.css
@@ -477,6 +477,7 @@ button.DialogButton:active, button.DialogButton.gpfocus {
 .friendsui-container .contextMenuItem {
 	color: var(--minimal_dark_less_white);
     background: var(--minimal_dark_be_grey);
+    transition: all .25s ease-in-out !important;
 }
 
 /* Bottom Part of Context Menu (Game Part) */

--- a/friends.custom.css
+++ b/friends.custom.css
@@ -433,28 +433,106 @@ button.DialogButton:active, button.DialogButton.gpfocus {
     overflow: hidden;
 }
 
-/* context menu ? */
+/* Context Menu Settings */
 
+
+/* BORDER RADIUS SETTINGS */
+
+/* First item in Top Part of Context Menu */
+.friendsui-container .contextMenuItem:first-child {
+    border-top-left-radius: var(--minimal_dark_corner) !important;
+    border-top-right-radius: var(--minimal_dark_corner) !important;
+}
+
+/* Last item in Top Part of Context Menu */
+.friendsui-container .contextMenuItem:last-child {
+    border-bottom-left-radius: var(--minimal_dark_corner) !important;
+    border-bottom-right-radius: var(--minimal_dark_corner) !important;
+}
+
+/* First item in Game Part of Context Menu */
+.friendsui-container .contextMenuGameOptions:first-child {
+    border-top-left-radius: 0px !important;
+    border-top-right-radius: 0px !important;
+}
+
+/* Last item in Game Part of Context Menu */
+.friendsui-container .contextMenuSectionContent:last-child {
+    border-bottom-left-radius: var(--minimal_dark_corner) !important;
+    border-bottom-right-radius: var(--minimal_dark_corner) !important;
+}
+
+/* First item in Online, Away etc. Menu */
+.friendsui-container .contextMenuSectionContent:first-child {
+    border-top-left-radius: var(--minimal_dark_corner) !important;
+    border-top-right-radius: var(--minimal_dark_corner) !important;
+}
+
+/* END OF BORDER RADIUS SETTINGS */
+
+
+/* REST OF CONTEXT MENU SETTINGS */
+
+/* Top Part of Context Menu (Friend Part) */
 .friendsui-container .contextMenuItem {
-	border-top:0 !important;
-	color: var(--minimal_dark_less_white) !important;
+	color: var(--minimal_dark_less_white);
+    background: var(--minimal_dark_be_grey);
 }
 
-.friendsui-container .contextMenuGameName {
-	color: white;
-}
-
-.friendsui-container .recentName {
-	color: var(--minimal_dark_light_blue);
-}
-
-.friendsui-container .contextMenuItem:hover, .friendsui-container .contextMenuItem._1KPWUt7wYWSfD3V7sYpsyT {
-	background: var(--minimal_dark_be_grey) !important;
-}
-
+/* Bottom Part of Context Menu (Game Part) */
 .friendsui-container .contextMenuGameTitle,.friendsui-container .contextMenuSectionContent,.friendsui-container .contextMenuGameOptions {
-	background: var(--minimal_dark_blacker_alt) !important;
+    color: var(--minimal_dark_less_white);
+    background: var(--minimal_dark_be_grey);
 }
+
+/* Game Font Color */
+.friendsui-container .contextMenuGameName {
+	color: #91C257;
+}
+
+/* Settings ONLY for the Game entry (Separates Friend & Game options nicely.) */
+.friendsui-container .contextMenuItem:has(.contextMenuGameName) {
+    background: var(--minimal_dark_black);
+    border-left: 2px solid #91C257 !important;
+}
+
+/* Hover Settings ONLY for the Game entry (I've set it so it don't change on hover as this button is unclickable.) */
+.friendsui-container .contextMenuItem:has(.contextMenuGameName):hover {
+    background: var(--minimal_dark_black) !important;
+}
+
+/* Manage -> Recent Names */
+.friendsui-container .recentName {
+	color: var(--minimal_dark_less_white);
+}
+
+/* Hover Settings of Context Menu Entries */
+.friendsui-container .contextMenuItem:hover, .friendsui-container .contextMenuItem._1KPWUt7wYWSfD3V7sYpsyT {
+    color: var(--minimal_dark_color);
+    background: var(--minimal_dark_blacker) !important; 
+}
+
+/* Context Menu Game Header Size */
+.contextMenuGameHeader {
+    width: 184px;
+    height: 69px;
+}
+
+/*Context Menu Game Header Mask */
+.contextMenuGameTitleBlurCropContainer {
+    -webkit-mask: none !important;
+    mask: none !important;
+    -webkit-mask-image: none !important;
+    mask-image: none !important;
+}
+
+/* Context Menu Game Header Hover Background (It's unclickable) */
+.friendsui-container .contextMenuItem:has(.contextMenuGameHeader):hover {
+    background: var(--minimal_dark_be_grey) !important;
+}
+
+/* End of Context Menu Settings */
+
 
 .friendsui-container .LQkrbbayZPY11qHm01t7F {
 	background: var(--minimal_dark_black) !important;

--- a/skin.json
+++ b/skin.json
@@ -1295,7 +1295,7 @@
 		},
 		
 		"Alternative root menu icon :": {
-		"tab": "Various options (11)",
+		"tab": "Various options (12)",
 		"description": "> Change the root menu icon with a alternative icon. \n\n - Minimal Dark : Half Steam logo. \n - Minimal Dark #1 : Full Steam logo. \n - Minimal Dark #2 : Rounded Steam logo (fill). \n - Minimal Dark #3 : Rounded Steam logo (oultine). \n - Minimal Dark #4 : Squared Steam logo (fill). \n - Minimal Dark #5 : Squared Steam logo (oultine).",
 		"default": "Minimal Dark",
 		"values": {
@@ -1329,7 +1329,7 @@
 		},
 
 		"Animated menu hovering :": {
-		"tab": "Various options (11)",
+		"tab": "Various options (12)",
 		"description": "> Enable this option if you want to have an animation on menus hover. \n\n - No : Static menus mouseover. \n - Yes : Animated menus mouseover.",
 		"default": "yes",
 		"values": {
@@ -1343,7 +1343,7 @@
 		},
 		
 		"Change UI font :": {
-		"tab": "Various options (11)",
+		"tab": "Various options (12)",
 		"description": "> Change the font of the interface. \n\n - Known bugs with topbar option 'Root menu Steam text' is disabled.",
 		"default": "Default",
 		"values": {
@@ -1387,7 +1387,7 @@
 		},
 		
 		"Context menus hover effect :": {
-		"tab": "Various options (11)",
+		"tab": "Various options (12)",
 		"description": "> Added a border to the left of the block with the user-defined color on the context menus when hover. \n\n - No hover effect : Static mouseover. \n - With hover effect : Animated mouseover.",
 		"default": "With hover effect",
 		"values": {
@@ -1401,7 +1401,7 @@
 		},
 		
 		"Default pointers :": {
-		"tab": "Various options (11)",
+		"tab": "Various options (12)",
 		"description": "> Display or hide pointers by default on the entire skin. \n\n - Steam : Steam default pointers. \n - Minimal Dark : Same cursor on the entire skin.",
 		"default": "Minimal Dark",
 		"values": {
@@ -1414,8 +1414,22 @@
 			}
 		},
 
+		"Extendium Patch :": {
+		"tab": "Various options (12)",
+		"description": "> Activate this option to patch Extendium Extensions icon. \n\n - No : Default. \n - Yes : Minimal Dark Color.",
+		"default": "yes",
+		"values": {
+			"no": {},
+			"yes": {
+			"TargetCss": {
+			"affects": [".*"], "src": "elements/options/various_options/extendium_patch.css"
+					}
+				}
+			}
+		},
+
 		"Hide scrollbars :": {
-		"tab": "Various options (11)",
+		"tab": "Various options (12)",
 		"description": "> Hide or show scrollbars. \n\n - Hide : Hide all scrollbars on the entirety of the skin. \n - Show : Show all scrollbars on the entirety of the skin.",
 		"default": "Show",
 		"values": {
@@ -1429,7 +1443,7 @@
 		},
 		
 		"Mouseover animation of settings menu tabs :": {
-		"tab": "Various options (11)",
+		"tab": "Various options (12)",
 		"description": "> Enable or disable the category hover effect in settings section. \n\n - Animated : Mouseover are animated. \n - Static : Mousesover are static.",
 		"default": "Animated",
 		"values": {
@@ -1443,7 +1457,7 @@
 		},
 		
 		"No titlebar (Linux) :": {
-		"tab": "Various options (11)",
+		"tab": "Various options (12)",
 		"description": "> Enable this option if you are using a tiled window manager in Linux and only use keyboard shortcuts to manage windows. \n\n - No : For Windows users. \n - Yes : If you are using a tiled window manager in Linux. \n\n Note : Leave this option disabled if you are on Windows.",
 		"default": "no",
 		"values": {
@@ -1457,7 +1471,7 @@
 		},
 		
 		"Pure black color (OLED) :": {
-		"tab": "Various options (11)",
+		"tab": "Various options (12)",
 		"description": "> Activate this option to enable pure black if you have an OLED screen. \n\n - No : Default color. \n - Yes : Pure black (oled)",
 		"default": "no",
 		"values": {
@@ -1471,7 +1485,7 @@
 		},
 		
 		"Windows corners fix :": {
-		"tab": "Various options (11)",
+		"tab": "Various options (12)",
 		"description": "> Same border radius value on all topbar buttons. \n\n No : Default values. \n Yes : Same values. \n\n NOTE : If you enable this option, you will need to disable the option directly below it, 'Windows 10 fix for root close corner'.",
 		"default": "yes",
 		"values": {
@@ -1485,7 +1499,7 @@
 		},
 		
 		"Windows 10 fix corners :": {
-		"tab": "Various options (11)",
+		"tab": "Various options (12)",
 		"description": "> Fix the top left corner & top right corner for Windows 10 users. \n\n NOTE : Disable this option if you enable the option directly above, 'Windows corners fix'.",
 		"default": "no",
 		"values": {


### PR DESCRIPTION
[Update header_glow.css](https://github.com/SaiyajinK/Minimal-Dark-for-Steam/pull/122/commits/7db8e2364fe879ff14b888c0d1977bb389ed216a)

Friends Options -> Friends List Header Glow Improvement

Removes Bleeding Glow from top of friends list.

before: 
<img width="639" height="19" alt="glow before" src="https://github.com/user-attachments/assets/d1713f74-c073-427e-9eeb-64dfe6b0efd0" />

after:
<img width="639" height="18" alt="glow after" src="https://github.com/user-attachments/assets/e03b9d84-e587-442c-98ff-f32dc44e1686" />
