### PR TITLE
Update vac_information.css

### DIFF
--- a/elements/options/webkit_options/vac/vac_information.css
+++ b/elements/options/webkit_options/vac/vac_information.css
@@ -1,3 +1,2 @@
-.profile_ban_status {
-	display: none !important;
-}
+:has(.btn_profile_action[href*="/edit/"]) .profile_ban_status {
+    display: none;


### PR DESCRIPTION
vac ban is now only hidden on the users end instead of all steam profiles